### PR TITLE
🗑 Deprecate aegis::io::stream for aegis::io::stream_view (Closes #2)

### DIFF
--- a/include/aegis/io.hpp
+++ b/include/aegis/io.hpp
@@ -5,12 +5,16 @@
 #include <aegis/types.hpp>
 #include <aegis/key.hpp>
 
+#include <apex/core/string.hpp>
 #include <apex/core/span.hpp>
 
-#include <string_view>
-#include <string>
-
 namespace aegis {
+
+template <> struct retain_traits<BIO> {
+  using reset_action = apex::adopt_t;
+  static void increment (BIO*) noexcept;
+  static void decrement (BIO*) noexcept;
+};
 
 template <> struct default_delete<BIO> {
   void operator () (BIO*) const noexcept;
@@ -20,7 +24,7 @@ template <> struct default_delete<BIO> {
 
 namespace aegis::io {
 
-struct stream : private unique_handle<BIO> {
+struct [[deprecated("use aegis::io::stream_view")]] stream : private unique_handle<BIO> {
   stream (apex::span<apex::byte>) noexcept;
   stream (std::string const&) noexcept;
   stream (std::string_view) noexcept;
@@ -29,6 +33,20 @@ struct stream : private unique_handle<BIO> {
 
 private:
   stream (void const*, size_t) noexcept;
+};
+
+struct stream_view : private retain_handle<BIO> {
+  stream_view (apex::span<apex::byte> const&) noexcept;
+  stream_view (std::string_view const&) noexcept;
+  stream_view (std::string const&) noexcept;
+
+  stream_view (apex::span<apex::byte>&&) = delete;
+  stream_view (std::string_view&&) = delete;
+  stream_view (std::string&&) = delete;
+
+  using resource_type::get;
+private:
+  stream_view (void const*, size_t) noexcept;
 };
 
 } /* namespace aegis::io */

--- a/include/aegis/key.hpp
+++ b/include/aegis/key.hpp
@@ -4,12 +4,12 @@
 #include <aegis/memory.hpp>
 #include <aegis/types.hpp>
 
-namespace aegis::io { struct stream; } /* namespace aegis::io */
+namespace aegis::io { struct stream_view; } /* namespace aegis::io */
 
 namespace aegis {
 
 struct private_key : view_handle<EVP_PKEY> {
-  private_key (io::stream const&) noexcept;
+  private_key (io::stream_view const&) noexcept;
   using view_handle<EVP_PKEY>::view_handle;
   using view_handle<EVP_PKEY>::get;
 };

--- a/include/aegis/x509.hpp
+++ b/include/aegis/x509.hpp
@@ -17,7 +17,7 @@ template <> struct retain_traits<X509> {
 
 } /* namespace aegis */
 
-namespace aegis::io { struct stream; } /* namespace aegis::io */
+namespace aegis::io { struct stream_view; } /* namespace aegis::io */
 
 namespace aegis::x509 {
 
@@ -27,7 +27,7 @@ struct name;
 
 struct certificate : private retain_handle<X509> {
 
-  certificate (io::stream const&) noexcept;
+  certificate (io::stream_view const&) noexcept;
 
   // TODO: use stack<ext::general_name> later
   stack<GENERAL_NAME> subject_alternative_names () const noexcept;

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -2,6 +2,9 @@
 
 namespace aegis {
 
+void retain_traits<BIO>::increment (BIO* ptr) noexcept { BIO_up_ref(ptr); }
+void retain_traits<BIO>::decrement (BIO* ptr) noexcept { BIO_free(ptr); }
+
 void default_delete<BIO>::operator () (BIO* ptr) const noexcept { BIO_free(ptr); }
 
 } /* namespace aegis */
@@ -22,6 +25,22 @@ stream::stream (std::string_view s) noexcept :
 
 stream::stream (void const* ptr, size_t length) noexcept :
   unique_handle<BIO> { BIO_new_mem_buf(ptr, length) }
+{ }
+
+stream_view::stream_view (apex::span<apex::byte> const& s) noexcept :
+  stream_view { s.data(), s.size() }
+{ }
+
+stream_view::stream_view (std::string_view const& s) noexcept :
+  stream_view { s.data(), s.size() }
+{ }
+
+stream_view::stream_view (std::string const& s) noexcept :
+  stream_view { s.data(), s.size() }
+{ }
+
+stream_view::stream_view (void const* ptr, size_t length) noexcept :
+  retain_handle<BIO> { BIO_new_mem_buf(ptr, length) }
 { }
 
 } /* namespace aegis::io */

--- a/src/key.cxx
+++ b/src/key.cxx
@@ -5,7 +5,7 @@
 
 namespace aegis {
 
-private_key::private_key (io::stream const& stream) noexcept :
+private_key::private_key (io::stream_view const& stream) noexcept :
   view_handle<EVP_PKEY> { PEM_read_bio_PrivateKey(stream.get(), nullptr, nullptr, nullptr) }
 { }
 

--- a/src/x509.cxx
+++ b/src/x509.cxx
@@ -15,7 +15,7 @@ void retain_traits<X509>::decrement (X509* ptr) noexcept { X509_free(ptr); }
 
 namespace aegis::x509 {
 
-certificate::certificate (io::stream const& stream) noexcept :
+certificate::certificate (io::stream_view const& stream) noexcept :
   retain_handle<X509> { PEM_read_bio_X509_AUX(stream.get(), nullptr, nullptr, nullptr) }
 { }
 


### PR DESCRIPTION
While this doesn't result in a full refactor, it will
1. Warn users to move to aegis::io::stream_view ASAP
2. Allow us to then repurpose aegis::io::stream to be a span/vector-like
   type where we can dynamically allocate the underlying storage and
   expand it safely. This will fix the underlying allocation issues
   we've run into as well
