### PR TITLE
🐛 Fix incorrect boolean logic in stack<T>::empty

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Build and Test
-on: push
+on:
+  push:
+    paths-ignore:
+      - docs/**
+      - .github/workflows/docs.yml
 jobs:
   build:
     name: Build Aegis

--- a/include/aegis/io.hpp
+++ b/include/aegis/io.hpp
@@ -16,24 +16,9 @@ template <> struct retain_traits<BIO> {
   static void decrement (BIO*) noexcept;
 };
 
-template <> struct default_delete<BIO> {
-  void operator () (BIO*) const noexcept;
-};
-
 } /* namespace aegis */
 
 namespace aegis::io {
-
-struct [[deprecated("use aegis::io::stream_view")]] stream : private unique_handle<BIO> {
-  stream (apex::span<apex::byte>) noexcept;
-  stream (std::string const&) noexcept;
-  stream (std::string_view) noexcept;
-
-  using unique_handle<BIO>::get;
-
-private:
-  stream (void const*, size_t) noexcept;
-};
 
 struct stream_view : private retain_handle<BIO> {
   stream_view (apex::span<apex::byte> const&) noexcept;

--- a/include/aegis/stack.hpp
+++ b/include/aegis/stack.hpp
@@ -212,8 +212,9 @@ struct stack : private unique_handle<typename stack_traits<T>::stack_type, stack
   [[nodiscard]] size_type reserve (size_type n) { return traits_type::reserve(this->get(), n); }
   [[nodiscard]] bool is_sorted () const noexcept;
 
+  /* returns -1 if this->get() == nullptr */
   [[nodiscard]] size_type size () const noexcept { return traits_type::size(this->get()); }
-  [[nodiscard]] bool empty () const noexcept { return this->get() and not this->size(); }
+  [[nodiscard]] bool empty () const noexcept { return this->size() <= 0; }
 };
 
 } /* namespace aegis */

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -5,27 +5,9 @@ namespace aegis {
 void retain_traits<BIO>::increment (BIO* ptr) noexcept { BIO_up_ref(ptr); }
 void retain_traits<BIO>::decrement (BIO* ptr) noexcept { BIO_free(ptr); }
 
-void default_delete<BIO>::operator () (BIO* ptr) const noexcept { BIO_free(ptr); }
-
 } /* namespace aegis */
 
 namespace aegis::io {
-
-stream::stream (apex::span<apex::byte> s) noexcept :
-  stream { s.data(), s.size() }
-{ }
-
-stream::stream (std::string const& s) noexcept :
-  stream { s.data(), s.size() }
-{ }
-
-stream::stream (std::string_view s) noexcept :
-  stream { s.data(), s.size() }
-{ }
-
-stream::stream (void const* ptr, size_t length) noexcept :
-  unique_handle<BIO> { BIO_new_mem_buf(ptr, length) }
-{ }
 
 stream_view::stream_view (apex::span<apex::byte> const& s) noexcept :
   stream_view { s.data(), s.size() }


### PR DESCRIPTION
👷 Don't run build workflow when updating documentation
🔥 Remove aegis::io::stream

  It was deprecated and is no longer in use anywhere
